### PR TITLE
ci(push-image): Add auto-releaser for Docker image

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -1,0 +1,38 @@
+name: Docker Auto Releaser
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  releaser:
+    name: Docker Image Auto Releaser
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Set tag version
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: megalotron/goflowmeter:latest,megalotron/goflowmeter:${{ steps.vars.outputs.tag }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Signed-off-by: Luca Georges Francois <luca.georges-francois@epitech.eu>

## Description

This PR adds a new CI which automatically pushes an image of goflowmeter to a Docker Hub repository whenever a tag is pushed.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

